### PR TITLE
Add image link in readme

### DIFF
--- a/documentation/StarterArchitecturePresentation.md
+++ b/documentation/StarterArchitecturePresentation.md
@@ -112,6 +112,11 @@ created by **thestarter.net**
 ![Nuxt](images/nuxt.png "Nuxt")
 ---
 
+## Architecture Diagram
+
+![Architecture Diagram](images/architecture_diagram.png "Architecture Diagram")
+---
+
 ## References
 
 - **Technology Practices Manual**:


### PR DESCRIPTION
fix: [Issue#49] Add architecture diagram link to the image in the presentation readme